### PR TITLE
API bump to alpha8

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -1,5 +1,5 @@
 name: HotBlock
 main: surva\hotblock\HotBlock
 version: 1.0.4
-api: [3.0.0-ALPHA1, 3.0.0-ALPHA2, 3.0.0-ALPHA3, 3.0.0-ALPHA4, 3.0.0-ALPHA5, 3.0.0-ALPHA6, 3.0.0-ALPHA7]
+api: [3.0.0-ALPHA8]
 depend: ["EconomyAPI"]

--- a/plugin.yml
+++ b/plugin.yml
@@ -1,5 +1,5 @@
 name: HotBlock
 main: surva\hotblock\HotBlock
 version: 1.0.4
-api: [3.0.0-ALPHA8]
+api: [3.0.0-ALPHA1, 3.0.0-ALPHA2, 3.0.0-ALPHA3, 3.0.0-ALPHA4, 3.0.0-ALPHA5, 3.0.0-ALPHA6, 3.0.0-ALPHA7, 3.0.0-ALPHA8]
 depend: ["EconomyAPI"]


### PR DESCRIPTION
Updated to ALPHA8 because no one uses pocketmine for minecraft 1.1 these days.
You can merge a few days/weeks later if you want. Just wanted to notice in case you're not following the latest api updates.