### PR TITLE
Normalize translation file path name when loading

### DIFF
--- a/src/surva/hotblock/HotBlock.php
+++ b/src/surva/hotblock/HotBlock.php
@@ -153,7 +153,8 @@ class HotBlock extends PluginBase
         $resources = $this->getResources();
 
         foreach ($resources as $resource) {
-            if (!preg_match("/languages\/[a-z]{2}.yml$/", $resource->getPathname())) {
+            $normalizedPath = Path::normalize($resource->getPathname());
+            if (!preg_match("/languages\/[a-z]{2}.yml$/", $normalizedPath)) {
                 continue;
             }
 


### PR DESCRIPTION
### 📋 What's this pull request about?

Normalise path of translation files which was causing problems when running from source on Windows.

### 🔧 Is this pull request related to an issue?

#51
